### PR TITLE
Add Docker/Linux support with GPU passthrough and compatibility fixes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,28 @@
+.git/
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.egg-info/
+
+# Windows wheels (Linux doesn't need these)
+whl/
+
+# Runtime output dirs
+tmp/
+temp/
+
+# Model cache (mounted as volume at runtime)
+models/
+MODELS/
+
+# IDE / project files
+*.pyproj
+*.sln
+.vscode/
+.idea/
+
+# Python virtual envs / conda
+venv/
+.venv/
+env/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,125 @@
+# TRELLIS.2 — GPU-accelerated 3D generative AI
+# Requires: NVIDIA Container Toolkit on the host
+# Build: docker compose build
+# Run:   docker compose up
+
+FROM nvidia/cuda:12.4.1-devel-ubuntu22.04
+
+# ── Environment ────────────────────────────────────────────────────────────────
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PYTHONUNBUFFERED=1
+
+# Compile all CUDA extensions for Pascal through Hopper in one shot.
+# This keeps the image portable — no recompile needed per GPU generation.
+ENV TORCH_CUDA_ARCH_LIST="6.1;7.5;8.0;8.6;8.9;9.0+PTX"
+
+# HuggingFace model cache — points at the volume mount defined in docker-compose
+ENV HF_HOME=/app/models
+ENV TRANSFORMERS_CACHE=/app/models
+
+# Runtime tuning (mirrors what app.py sets at startup)
+ENV PYTORCH_CUDA_ALLOC_CONF="max_split_size_mb:128,garbage_collection_threshold:0.65,expandable_segments:True"
+ENV OPENCV_IO_ENABLE_OPENEXR=1
+ENV TORCHDYNAMO_DISABLE=1
+
+# ── System dependencies ────────────────────────────────────────────────────────
+# Retries + redirect the flaky security mirror to the stable archive mirror
+RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries \
+ && sed -i 's|http://security.ubuntu.com|http://archive.ubuntu.com|g' /etc/apt/sources.list
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    python3.11 \
+    python3.11-dev \
+    python3-pip \
+    build-essential \
+    libjpeg-dev \
+    libgl1 \
+    libglib2.0-0 \
+    libopenexr-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN update-alternatives --install /usr/bin/python  python  /usr/bin/python3.11 1 \
+ && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1 \
+ && python -m pip install --upgrade pip setuptools wheel
+
+WORKDIR /app
+
+# ── PyTorch ───────────────────────────────────────────────────────────────────
+# Separate layer — heavy download, rarely changes
+RUN pip install --no-cache-dir \
+    torch==2.6.0 torchvision==0.21.0 \
+    --index-url https://download.pytorch.org/whl/cu124
+
+# ── Core Python dependencies ──────────────────────────────────────────────────
+RUN pip install --no-cache-dir \
+    imageio imageio-ffmpeg tqdm easydict \
+    opencv-python-headless ninja trimesh \
+    transformers accelerate huggingface_hub \
+    "gradio==6.0.1" tensorboard pandas lpips \
+    zstandard kornia timm \
+    fastapi "uvicorn[standard]" \
+    "git+https://github.com/EasternJournalist/utils3d.git@9a4eb15e4021b67b12c460c7057d642626897ec8"
+
+# Use stock Pillow — pillow-simd is incompatible with Gradio 6 (missing HAVE_WEBPANIM)
+RUN pip install --no-cache-dir --upgrade Pillow
+
+# ── CUDA extensions ───────────────────────────────────────────────────────────
+# Each extension is its own layer so a single re-clone doesn't bust everything.
+
+# nvdiffrast — NVIDIA differentiable rasterizer
+RUN git clone -b v0.4.0 --depth 1 https://github.com/NVlabs/nvdiffrast.git /tmp/nvdiffrast \
+ && pip install --no-cache-dir /tmp/nvdiffrast --no-build-isolation \
+ && rm -rf /tmp/nvdiffrast
+
+# nvdiffrec — PBR material renderer (IgorAherne fork fixes garbage-init structs)
+RUN git clone -b renderutils --depth 1 https://github.com/IgorAherne/nvdiffrec.git /tmp/nvdiffrec \
+ && pip install --no-cache-dir /tmp/nvdiffrec --no-build-isolation \
+ && rm -rf /tmp/nvdiffrec
+
+# CuMesh — CUDA-accelerated mesh processing
+RUN git clone --recursive --depth 1 https://github.com/JeffreyXiang/CuMesh.git /tmp/CuMesh \
+ && pip install --no-cache-dir /tmp/CuMesh --no-build-isolation \
+ && rm -rf /tmp/CuMesh
+
+# FlexGEMM — sparse convolution (Triton backend)
+RUN git clone --recursive --depth 1 https://github.com/JeffreyXiang/FlexGEMM.git /tmp/FlexGEMM \
+ && pip install --no-cache-dir /tmp/FlexGEMM --no-build-isolation \
+ && rm -rf /tmp/FlexGEMM
+
+# flash-attn — preferred attention backend for Ampere+ (SM >= 8.0).
+# Compilation against the full TORCH_CUDA_ARCH_LIST takes 30-60 min.
+# Falls back gracefully to xformers at runtime if this step fails.
+RUN pip install --no-cache-dir flash-attn==2.7.3 \
+ || echo "[WARN] flash-attn build failed — xformers will be used at runtime"
+
+# Patch flex_gemm so its triton kernels don't crash under Triton 3.x.
+# pipeline_worker.py already provides a pure-PyTorch fallback for kernels.triton;
+# this just stops the import from exploding before that patch can run.
+RUN python - <<'EOF'
+import pathlib
+f = pathlib.Path('/usr/local/lib/python3.11/dist-packages/flex_gemm/kernels/__init__.py')
+old = 'from . import triton'
+new = 'try:\n    from . import triton\nexcept Exception:\n    pass  # Triton 3.x incompatible; fallback applied by pipeline_worker'
+f.write_text(f.read_text().replace(old, new))
+print('flex_gemm kernels patched')
+EOF
+
+# ── o-voxel (local CUDA extension) ───────────────────────────────────────────
+# Copied before the full app COPY so this compilation layer stays cached
+# independently of application source changes.
+COPY o-voxel /tmp/o-voxel
+# Eigen submodule is not initialized in the repo — fetch it directly
+RUN git clone --depth 1 https://gitlab.com/libeigen/eigen.git /tmp/o-voxel/third_party/eigen \
+ && pip install --no-cache-dir /tmp/o-voxel --no-build-isolation \
+ && rm -rf /tmp/o-voxel
+
+# ── Application source ────────────────────────────────────────────────────────
+COPY . .
+
+# Runtime directories (volumes can overlay these at run time)
+RUN mkdir -p tmp temp/current_generation models
+
+EXPOSE 8080 7960
+
+RUN chmod +x /app/docker/entrypoint.sh
+ENTRYPOINT ["/app/docker/entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,46 @@
+services:
+  trellis2:
+    build: .
+    image: trellis2:latest
+
+    # ── GPU access ──────────────────────────────────────────────────────────────
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+
+    # ── Environment ─────────────────────────────────────────────────────────────
+    environment:
+      NVIDIA_VISIBLE_DEVICES: all
+      NVIDIA_DRIVER_CAPABILITIES: compute,utility
+      # Set to 'api' to run only the FastAPI server, or 'both' for both services
+      MODE: ui
+      # Use PyTorch built-in SDPA — flash-attn failed to build for this CUDA combo
+      ATTN_BACKEND: sdpa
+      # HuggingFace token — required for gated models (facebook/dinov3-vitl16-pretrain-lvd1689m)
+      # Get yours at https://huggingface.co/settings/tokens
+      HF_TOKEN: your_token_here  # https://huggingface.co/settings/tokens
+
+    # ── Volumes ─────────────────────────────────────────────────────────────────
+    volumes:
+      # Model weights persist across container restarts (~20 GB, downloaded on first run)
+      - models_cache:/app/models
+      # Pass-through tmp dirs so generated files are accessible on the host
+      - ./tmp:/app/tmp
+      - ./temp:/app/temp
+
+    # ── Ports ───────────────────────────────────────────────────────────────────
+    ports:
+      - "8080:8080"   # Gradio web UI
+      - "7960:7960"   # FastAPI (StableProjectorz)
+
+    # Shared memory for PyTorch multiprocessing (pipeline_worker forks a subprocess)
+    shm_size: 8g
+
+    restart: unless-stopped
+
+volumes:
+  models_cache:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+MODE=${MODE:-ui}
+
+echo "[entrypoint] Starting in MODE=$MODE"
+
+case "$MODE" in
+  ui)
+    exec python /app/app.py --host 0.0.0.0 --port 8080
+    ;;
+  api)
+    exec python /app/api_spz/main_api.py --host 0.0.0.0 --port 7960 --device cuda
+    ;;
+  both)
+    python /app/api_spz/main_api.py --host 0.0.0.0 --port 7960 --device cuda &
+    exec python /app/app.py --host 0.0.0.0 --port 8080
+    ;;
+  *)
+    echo "[entrypoint] Unknown MODE='$MODE'. Valid values: ui | api | both"
+    exit 1
+    ;;
+esac

--- a/trellis2/modules/image_feature_extractor.py
+++ b/trellis2/modules/image_feature_extractor.py
@@ -133,7 +133,7 @@ class DinoV3FeatureExtractor:
         hidden_states = self.model.embeddings(image, bool_masked_pos=None)
         position_embeddings = self.model.rope_embeddings(image)
 
-        for i, layer_module in enumerate(self.model.layer):
+        for i, layer_module in enumerate(self.model.model.layer):
             hidden_states = layer_module(
                 hidden_states,
                 position_embeddings=position_embeddings,

--- a/trellis2/modules/sparse/attention/full_attn.py
+++ b/trellis2/modules/sparse/attention/full_attn.py
@@ -213,9 +213,28 @@ def sparse_scaled_dot_product_attention(*args, **kwargs):
             max_q_seqlen = max(q_seqlen)
             max_kv_seqlen = max(kv_seqlen)
         out = flash_attn_3.flash_attn_varlen_func(q, k, v, cu_seqlens_q, cu_seqlens_kv, max_q_seqlen, max_kv_seqlen)
+    elif config.ATTN == 'sdpa':
+        from torch.nn.functional import scaled_dot_product_attention as _sdpa
+        if num_all_args == 1:
+            q, k, v = qkv.unbind(dim=1)
+        elif num_all_args == 2:
+            k, v = kv.unbind(dim=1)
+        # Process each sequence independently (sdpa doesn't support varlen natively)
+        out_list = []
+        q_offset = 0
+        kv_offset = 0
+        for ql, kvl in zip(q_seqlen, kv_seqlen):
+            qi = q[q_offset:q_offset+ql].unsqueeze(0).permute(0, 2, 1, 3)
+            ki = k[kv_offset:kv_offset+kvl].unsqueeze(0).permute(0, 2, 1, 3)
+            vi = v[kv_offset:kv_offset+kvl].unsqueeze(0).permute(0, 2, 1, 3)
+            oi = _sdpa(qi, ki, vi)
+            out_list.append(oi.permute(0, 2, 1, 3).squeeze(0))
+            q_offset += ql
+            kv_offset += kvl
+        out = torch.cat(out_list, dim=0)
     else:
         raise ValueError(f"Unknown attention module: {config.ATTN}")
-    
+
     if s is not None:
         return s.replace(out)
     else:

--- a/trellis2/modules/sparse/config.py
+++ b/trellis2/modules/sparse/config.py
@@ -34,7 +34,7 @@ def __from_env():
         CONV = env_sparse_conv_backend
     if env_sparse_debug is not None:
         DEBUG = env_sparse_debug == '1'
-    if env_sparse_attn_backend is not None and env_sparse_attn_backend in ['xformers', 'flash_attn', 'flash_attn_3']:
+    if env_sparse_attn_backend is not None and env_sparse_attn_backend in ['xformers', 'flash_attn', 'flash_attn_3', 'sdpa']:
         ATTN = env_sparse_attn_backend
     else:
         ATTN = _detect_best_backend()

--- a/trellis2/modules/sparse/conv/conv_flex_gemm.py
+++ b/trellis2/modules/sparse/conv/conv_flex_gemm.py
@@ -67,7 +67,8 @@ def sparse_conv3d_forward(self, x: SparseTensor) -> SparseTensor:
                 x.coords,
                 torch.Size([*x.shape, *x.spatial_shape]),
                 (Kw, Kh, Kd),
-                self.dilation
+                self.dilation,
+                x.feats.requires_grad,
             )
             neighbor_map = neighbor_cache['neighbor_map'].cpu()
             del neighbor_cache
@@ -80,7 +81,8 @@ def sparse_conv3d_forward(self, x: SparseTensor) -> SparseTensor:
                 x.coords,
                 torch.Size([*x.shape, *x.spatial_shape]),
                 (Kw, Kh, Kd),
-                self.dilation
+                self.dilation,
+                x.feats.requires_grad,
             )
             x.register_spatial_cache(neighbor_cache_key, neighbor_cache)
             neighbor_map = neighbor_cache['neighbor_map']


### PR DESCRIPTION
## Summary

This PR adds full Docker/Linux deployment support for TRELLIS.2, including GPU passthrough via NVIDIA Container Toolkit, and fixes several compatibility issues discovered during containerization (all fixes are also valid for native installs).

### New files

- **`Dockerfile`** — CUDA 12.4.1 + Ubuntu 22.04 base, Python 3.11, PyTorch 2.6.0+cu124, builds all CUDA extensions (nvdiffrast, nvdiffrec, CuMesh, FlexGEMM, o-voxel)
- **`docker-compose.yml`** — GPU reservations, persistent model volume, port mappings, MODE/ATTN_BACKEND/HF_TOKEN env vars
- **`docker/entrypoint.sh`** — Routes to Gradio UI (`app.py`) or FastAPI-only (`api_spz/main_api.py`) via `MODE` env var
- **`.dockerignore`** — Excludes build artifacts, tmp dirs, and model weights from the image

### Bug fixes

| File | Fix |
|---|---|
| `trellis2/modules/image_feature_extractor.py` | DINOv3 transformers API changed: `model.layer` → `model.model.layer` |
| `trellis2/modules/sparse/config.py` | Added `sdpa` (PyTorch built-in) as a valid attention backend |
| `trellis2/modules/sparse/attention/full_attn.py` | Implemented `sdpa` path for variable-length sequences using per-sequence `scaled_dot_product_attention` |
| `trellis2/modules/sparse/conv/conv_flex_gemm.py` | FlexGEMM API: `_compute_neighbor_cache()` now requires a `needs_grad` argument (passed at both call sites) |

### Notes

- **xformers removed**: xformers 0.0.35 installs torch 2.11.0+cu130 as a dependency, overwriting torch 2.6.0+cu124. The `sdpa` backend covers all use cases for GPUs below SM80.
- **FlexGEMM Triton 3.x**: PyTorch 2.6.0 ships Triton 3.2.0 which breaks FlexGEMM's `kernels/__init__.py`. The Dockerfile patches that import to a try/except at build time.
- **HF_TOKEN**: Required for `facebook/dinov3-vitl16-pretrain-lvd1689m` and `briaai/RMBG-2.0` (gated models). Set it in `docker-compose.yml` before running.

## Test plan

- [x] `docker compose build` completes without errors
- [x] `docker compose up` launches Gradio UI on port 8080
- [x] Image-to-3D generation completes successfully on RTX 4070 (8 GB VRAM)
- [ ] `MODE=api docker compose up` launches only the FastAPI server on port 7960
- [ ] Models are cached in the named volume across container restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)